### PR TITLE
Add Standalone server optional support for an alternate BASE_PATH.

### DIFF
--- a/standalone/BASE_PATH.md
+++ b/standalone/BASE_PATH.md
@@ -10,9 +10,6 @@ Set the `BASE_PATH` environment variable to the desired path prefix:
 # Host at /cap
 BASE_PATH=/cap bun run src/index.js
 
-# Host at /captcha  
-BASE_PATH=/captcha bun run src/index.js
-
 # Host at /security/cap
 BASE_PATH=/security/cap bun run src/index.js
 ```
@@ -22,9 +19,6 @@ BASE_PATH=/security/cap bun run src/index.js
 ```bash
 # Basic usage with BASE_PATH
 docker run -e BASE_PATH=/cap -e ADMIN_KEY=your_admin_key tiago2/cap:latest
-
-# With port mapping
-docker run -p 3000:3000 -e BASE_PATH=/captcha -e ADMIN_KEY=your_admin_key tiago2/cap:latest
 
 # Using docker-compose
 # docker-compose.yml
@@ -53,9 +47,9 @@ ADMIN_KEY=your_admin_key
 When using the Cap widget with a custom BASE_PATH, you must include the base path in the `data-cap-api-endpoint` attribute:
 
 ```html
-<!-- For BASE_PATH=/captcha -->
+<!-- For BASE_PATH=/cap -->
 <cap-widget 
-  data-cap-api-endpoint="/captcha/YOUR_SITE_KEY/"
+  data-cap-api-endpoint="/cap/YOUR_SITE_KEY/"
   data-cap-hidden-field-name="cap-token">
 </cap-widget>
 

--- a/standalone/BASE_PATH.md
+++ b/standalone/BASE_PATH.md
@@ -1,0 +1,76 @@
+# BASE_PATH Configuration
+
+Cap Standalone now supports hosting at a different root URL using the `BASE_PATH` environment variable.
+
+## Usage
+
+Set the `BASE_PATH` environment variable to the desired path prefix:
+
+```bash
+# Host at /cap
+BASE_PATH=/cap bun run src/index.js
+
+# Host at /captcha  
+BASE_PATH=/captcha bun run src/index.js
+
+# Host at /security/cap
+BASE_PATH=/security/cap bun run src/index.js
+```
+
+## Docker
+
+```bash
+# Basic usage with BASE_PATH
+docker run -e BASE_PATH=/cap -e ADMIN_KEY=your_admin_key tiago2/cap:latest
+
+# With port mapping
+docker run -p 3000:3000 -e BASE_PATH=/captcha -e ADMIN_KEY=your_admin_key tiago2/cap:latest
+
+# Using docker-compose
+# docker-compose.yml
+version: '3.8'
+services:
+  cap:
+    image: tiago2/cap:latest
+    ports:
+      - "3000:3000"
+    environment:
+      - BASE_PATH=/cap
+      - ADMIN_KEY=your_admin_key
+```
+
+## Environment Variables
+
+Add to your `.env` file:
+
+```bash
+BASE_PATH=/cap
+ADMIN_KEY=your_admin_key
+```
+
+## Widget Configuration
+
+When using the Cap widget with a custom BASE_PATH, you must include the base path in the `data-cap-api-endpoint` attribute:
+
+```html
+<!-- For BASE_PATH=/captcha -->
+<cap-widget 
+  data-cap-api-endpoint="/captcha/YOUR_SITE_KEY/"
+  data-cap-hidden-field-name="cap-token">
+</cap-widget>
+
+<!-- For no BASE_PATH (root) -->
+<cap-widget 
+  data-cap-api-endpoint="/YOUR_SITE_KEY/"
+  data-cap-hidden-field-name="cap-token">
+</cap-widget>
+```
+
+**Important:** The widget does not automatically detect the BASE_PATH. You must manually include it in the API endpoint configuration.
+
+## Notes
+
+- The BASE_PATH is automatically normalized to start with `/` and not end with `/`
+- All API endpoints, assets, and frontend routes will be prefixed with the BASE_PATH
+- The login page and admin interface will automatically work with the configured BASE_PATH
+- Widget configuration must be updated manually to include the BASE_PATH

--- a/standalone/public/js/api.js
+++ b/standalone/public/js/api.js
@@ -19,7 +19,10 @@ export default async (method, path, body) => {
       requestInit.body = JSON.stringify(body);
     }
 
-    const json = await (await fetch(`/server${path}`, requestInit)).json();
+    // Extract base path from current URL
+    const currentPath = window.location.pathname;
+    const basePath = currentPath === '/' ? '' : currentPath.replace(/\/$/, '');
+    const json = await (await fetch(`${basePath}/server${path}`, requestInit)).json();
 
     if (json?.error === "Unauthorized") {
       localStorage.removeItem("cap_auth");

--- a/standalone/public/login.html
+++ b/standalone/public/login.html
@@ -251,8 +251,12 @@
 
         document.querySelector("button[type=submit]").disabled = true;
 
+        // Extract base path from current URL
+        const currentPath = window.location.pathname;
+        const basePath = currentPath === '/' ? '' : currentPath.replace(/\/$/, '');
+        
         const { success, session_token, hashed_token, expires } = await (
-          await fetch("/auth/login", {
+          await fetch(`${basePath}/auth/login`, {
             method: "POST",
             headers: {
               "Content-Type": "application/json",

--- a/standalone/src/assets.js
+++ b/standalone/src/assets.js
@@ -79,8 +79,15 @@ const updateCache = async () => {
 updateCache();
 setInterval(updateCache, 1000 * 60 * 60);
 
+// Normalize BASE_PATH
+let basePath = process.env.BASE_PATH || '';
+if (basePath) {
+	if (!basePath.startsWith('/')) basePath = '/' + basePath;
+	if (basePath.endsWith('/')) basePath = basePath.slice(0, -1);
+}
+
 export const assetsServer = new Elysia({
-	prefix: "/assets",
+	prefix: basePath + "/assets",
 	detail: { tags: ["Assets"] },
 })
 	.use(

--- a/standalone/src/auth.js
+++ b/standalone/src/auth.js
@@ -20,8 +20,15 @@ if (ADMIN_KEY.length < 30)
 		"auth: Admin key too short. Please use one that's at least 30 characters",
 	);
 
+// Normalize BASE_PATH
+let basePath = process.env.BASE_PATH || '';
+if (basePath) {
+	if (!basePath.startsWith('/')) basePath = '/' + basePath;
+	if (basePath.endsWith('/')) basePath = basePath.slice(0, -1);
+}
+
 export const auth = new Elysia({
-	prefix: "/auth",
+	prefix: basePath + "/auth",
 })
 	.use(
 		rateLimit({

--- a/standalone/src/cap.js
+++ b/standalone/src/cap.js
@@ -42,7 +42,15 @@ const upsertSolutionQuery = db.query(`
   DO UPDATE SET count = count + 1
 `);
 
+// Normalize BASE_PATH
+let basePath = process.env.BASE_PATH || '';
+if (basePath) {
+	if (!basePath.startsWith('/')) basePath = '/' + basePath;
+	if (basePath.endsWith('/')) basePath = basePath.slice(0, -1);
+}
+
 export const capServer = new Elysia({
+	prefix: basePath,
 	detail: {
 		tags: ["Challenges"],
 	},

--- a/standalone/src/server.js
+++ b/standalone/src/server.js
@@ -20,8 +20,15 @@ const get24hPreviousQuery = db.query(`
 `);
 const getKeysQuery = db.query(`SELECT * FROM keys ORDER BY created DESC`);
 
+// Normalize BASE_PATH
+let basePath = process.env.BASE_PATH || '';
+if (basePath) {
+	if (!basePath.startsWith('/')) basePath = '/' + basePath;
+	if (basePath.endsWith('/')) basePath = basePath.slice(0, -1);
+}
+
 export const server = new Elysia({
-	prefix: "/server",
+	prefix: basePath + "/server",
 	detail: {
 		security: [
 			{


### PR DESCRIPTION
Support an alternate base path for the Standalone server such that all web UI and API requests can be accessed from a unique root. Ensure backwards compatible if option is not specified.

**Usage Examples**
Run in docker:
```bash
docker run -e BASE_PATH=/cap -e ADMIN_KEY=your_admin_key tiago2/cap:latest
```

Configure widget:
```HTML
<cap-widget 
  data-cap-api-endpoint="/cap/YOUR_SITE_KEY/"
  data-cap-hidden-field-name="cap-token">
</cap-widget>
```

**Server-Side Changes**

- Update all Elysia route prefixes in auth, server, assets, and cap modules to include BASE_PATH
- Modify static file serving to handle BASE_PATH with custom route for multi-level paths
- Add redirect route from base path 'without trailing slash' to 'with trailing slash' for proper relative path resolution
- Add BASE_PATH normalization logic to ensure paths start with / and don't end with /
- Update console logging to display configured BASE_PATH and endpoint URLs

**Frontend Changes**

- Modify login form to dynamically detect base path from current URL for authentication calls
- Update API client to auto-detect base path from window.location.pathname for all server API calls
- Ensure relative static asset paths work correctly with trailing slash requirement