### PR TITLE
feat(standalone): add Redis Cluster support via ioredis

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,3 +100,45 @@ jobs:
         env:
           REDIS_URL: redis://127.0.0.1:6379
         run: bun test
+
+  standalone-cluster:
+    name: cap-standalone (cluster)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      # A GitHub Actions service container cannot override its command, and a
+      # cluster node would otherwise announce an unreachable internal IP, so the
+      # node is started manually with --cluster-announce-ip pointing at the runner.
+      - name: Start single-node Valkey cluster
+        run: |
+          docker run -d --name valkey-cluster -p 6379:6379 valkey/valkey:9-alpine \
+            valkey-server --cluster-enabled yes --cluster-config-file nodes.conf \
+            --cluster-node-timeout 5000 --appendonly no --loglevel warning \
+            --cluster-announce-ip 127.0.0.1 --cluster-announce-port 6379
+          for i in $(seq 1 30); do
+            if docker exec valkey-cluster valkey-cli ping | grep -q PONG; then break; fi
+            sleep 1
+          done
+          docker exec valkey-cluster valkey-cli --cluster create 127.0.0.1:6379 --cluster-yes
+          for i in $(seq 1 30); do
+            if docker exec valkey-cluster valkey-cli cluster info | grep -q cluster_state:ok; then
+              echo "cluster ready"; exit 0
+            fi
+            sleep 1
+          done
+          echo "cluster did not reach cluster_state:ok"; exit 1
+      - name: Install (core)
+        working-directory: core
+        run: bun install --frozen-lockfile
+      - name: Install (standalone)
+        working-directory: standalone
+        run: bun install --frozen-lockfile
+      - name: Test
+        working-directory: standalone
+        env:
+          REDIS_CLUSTER: "true"
+          REDIS_URL: redis://127.0.0.1:6379
+        run: bun test

--- a/docs/guide/standalone/options.md
+++ b/docs/guide/standalone/options.md
@@ -57,6 +57,23 @@ The recommended setup uses Valkey (a Redis-compatible store) via the docker-comp
 
 If you share a single Redis instance across multiple Cap deployments (or with other apps), set `REDIS_PREFIX` to namespace all keys. For example, `REDIS_PREFIX=cap:` stores sessions as `cap:session:...`, metrics as `cap:metrics:...`, and so on. It's empty by default, so existing deployments are unaffected.
 
+### High availability (Redis Cluster)
+
+For high availability, Cap Standalone can connect to a Redis/Valkey Cluster. Set `REDIS_CLUSTER=true` and point `REDIS_URL` at one or more seed nodes (comma-separated):
+
+```
+REDIS_CLUSTER=true
+REDIS_URL=redis://node-1:6379,redis://node-2:6379,redis://node-3:6379
+```
+
+The client then discovers the full topology from the seeds and routes each command to the node owning its key, surviving the loss of any single master. When `REDIS_CLUSTER` is unset (the default), Cap connects to a single Redis/Valkey instance as before. `REDIS_PREFIX` and authentication/TLS in the URL work the same way in both modes.
+
+A single-node cluster compose file for exercising this locally is provided at `standalone/docker-compose.cluster.yml` (testing only, it provides no failover). Real high availability requires at least 3 masters and 3 replicas, or a managed cluster.
+
+Notes:
+- Redis **Sentinel** is not supported; use Cluster mode for HA.
+- All of Cap's commands operate on a single key, so they route cleanly across cluster slots.
+
 ## Error messages
 
 Error messages are redacted by default and instead logged to the console. To disable error logging, set `DISABLE_ERROR_LOGGING=true`. To disable error message redaction, set `SHOW_ERRORS=true`.

--- a/docs/guide/standalone/options.md
+++ b/docs/guide/standalone/options.md
@@ -55,7 +55,31 @@ Cap Standalone uses Redis (or Valkey) for all data storage. Set the `REDIS_URL` 
 
 The recommended setup uses Valkey (a Redis-compatible store) via the docker-compose file provided in the [quickstart guide](/guide/standalone/).
 
-If you share a single Redis instance across multiple Cap deployments (or with other apps), set `REDIS_PREFIX` to namespace all keys. For example, `REDIS_PREFIX=cap:` stores sessions as `cap:session:...`, metrics as `cap:metrics:...`, and so on. It's empty by default, so existing deployments are unaffected.
+### Connection string
+
+`REDIS_URL` (or `VALKEY_URL`) accepts the standard formats:
+
+```
+redis://localhost:6379                  # plain
+redis://localhost:6379/0                # with database number
+redis://user:password@localhost:6379    # with authentication
+rediss://user:password@host:6379        # TLS (note the double "s")
+```
+
+### Key prefix
+
+If you share a single Redis instance across multiple Cap deployments (or with other apps), set `REDIS_PREFIX` to namespace all keys. For example, `REDIS_PREFIX=cap:` stores sessions as `cap:session:...`, metrics as `cap:metrics:...`, and so on:
+
+```
+REDIS_PREFIX=cap:
+```
+
+It's **empty by default**, and this matters:
+
+- **New deployment:** setting `REDIS_PREFIX=cap:` from the start is a good convention, especially on a shared instance.
+- **Existing deployment:** do **not** add a prefix to a running instance without migrating. Cap would start looking for `cap:key:...` while your data lives under `key:...`, making every existing site, session and metric invisible (it looks like data loss). Rename the keys first, or only introduce a prefix on a fresh instance.
+
+The prefix is applied transparently to every command; it has no effect on cluster routing (it is included consistently in the slot calculation).
 
 ### High availability (Redis Cluster)
 
@@ -66,13 +90,36 @@ REDIS_CLUSTER=true
 REDIS_URL=redis://node-1:6379,redis://node-2:6379,redis://node-3:6379
 ```
 
-The client then discovers the full topology from the seeds and routes each command to the node owning its key, surviving the loss of any single master. When `REDIS_CLUSTER` is unset (the default), Cap connects to a single Redis/Valkey instance as before. `REDIS_PREFIX` and authentication/TLS in the URL work the same way in both modes.
+You only need to list a couple of reachable seed nodes; the client discovers the full topology from them and keeps it refreshed. The prefix, authentication and TLS work the same way in both modes — for an authenticated TLS cluster:
 
-A single-node cluster compose file for exercising this locally is provided at `standalone/docker-compose.cluster.yml` (testing only, it provides no failover). Real high availability requires at least 3 masters and 3 replicas, or a managed cluster.
+```
+REDIS_CLUSTER=true
+REDIS_URL=rediss://user:password@node-1:6379,rediss://user:password@node-2:6379
+REDIS_PREFIX=cap:
+```
 
-Notes:
+When `REDIS_CLUSTER` is unset (the default), Cap connects to a single Redis/Valkey instance exactly as before.
+
+#### How it behaves
+
+- **Routing:** every command is sent to the master owning its key's slot. Reads and writes both go to masters (no stale reads from replicas), which is what Cap's counters, nonces and tokens require.
+- **Node failure:** if a master goes down, the client detects it, retries, and reroutes to the promoted replica once the cluster elects one — automatically, no application code involved. During the election window (driven by `cluster-node-timeout` plus election time, typically a few seconds), requests whose keys live on the affected shard may be slower or fail with an error; they never return an incorrect verification. Other shards keep serving.
+- **Replicas are required:** failover only works if each master has at least one replica to promote.
+
+#### Local testing
+
+A single-node cluster compose file is provided at `standalone/docker-compose.cluster.yml`:
+
+```sh
+docker compose -f docker-compose.cluster.yml up -d
+```
+
+It exercises the cluster code path (topology discovery, slot routing) with one master owning all 16384 slots. It is for **testing only** — a single node has no replica, so it provides **no failover**. Real high availability requires at least 3 masters and 3 replicas, or a managed Valkey/Redis cluster, with `REDIS_URL` pointing at the seed nodes.
+
+#### Notes and limitations
+
 - Redis **Sentinel** is not supported; use Cluster mode for HA.
-- All of Cap's commands operate on a single key, so they route cleanly across cluster slots.
+- All of Cap's commands operate on a single key, so they route cleanly across cluster slots (no `CROSSSLOT` errors).
 
 ## Error messages
 

--- a/standalone/bun.lock
+++ b/standalone/bun.lock
@@ -9,6 +9,7 @@
         "@elysiajs/swagger": "^1.3.1",
         "capjs-core": "^0.1.1",
         "elysia": "^1.4.28",
+        "ioredis": "^5.11.1",
         "maxmind": "^5.0.6",
       },
       "devDependencies": {
@@ -81,6 +82,8 @@
 
     "@inversifyjs/reflect-metadata-utils": ["@inversifyjs/reflect-metadata-utils@0.2.3", "", { "peerDependencies": { "reflect-metadata": "0.2.2" } }, "sha512-d3D0o9TeSlvaGM2I24wcNw/Aj3rc4OYvHXOKDC09YEph5fMMiKd6fq1VTQd9tOkDNWvVbw+cnt45Wy9P/t5Lvw=="],
 
+    "@ioredis/commands": ["@ioredis/commands@1.10.0", "", {}, "sha512-UmeW7z4LfctwoQ5wkhVzgq8tXkreED2xZGpX+Bg+zA+WJFZCT6c062AfCK/Dfk81xZnnwdhJCUMkitihRaoC2Q=="],
+
     "@javascript-obfuscator/escodegen": ["@javascript-obfuscator/escodegen@2.3.1", "", { "dependencies": { "@javascript-obfuscator/estraverse": "^5.3.0", "esprima": "^4.0.1", "esutils": "^2.0.2", "optionator": "^0.8.1" }, "optionalDependencies": { "source-map": "~0.6.1" } }, "sha512-Z0HEAVwwafOume+6LFXirAVZeuEMKWuPzpFbQhCEU9++BMz0IwEa9bmedJ+rMn/IlXRBID9j3gQ0XYAa6jM10g=="],
 
     "@javascript-obfuscator/estraverse": ["@javascript-obfuscator/estraverse@5.4.0", "", {}, "sha512-CZFX7UZVN9VopGbjTx4UXaXsi9ewoM1buL0kY7j1ftYdSs7p2spv9opxFjHlQ/QGTgh4UqufYqJJ0WKLml7b6w=="],
@@ -151,6 +154,8 @@
 
     "class-validator": ["class-validator@0.14.3", "", { "dependencies": { "@types/validator": "^13.15.3", "libphonenumber-js": "^1.11.1", "validator": "^13.15.20" } }, "sha512-rXXekcjofVN1LTOSw+u4u9WXVEUvNBVjORW154q/IdmYWy1nMbOU9aNtZB0t8m+FJQ9q91jlr2f9CwwUFdFMRA=="],
 
+    "cluster-key-slot": ["cluster-key-slot@1.1.1", "", {}, "sha512-rwHwUfXL40Chm1r08yrhU3qpUvdVlgkKNeyeGPOxnW8/SyVDvgRaed/Uz54AqWNaTCAThlj6QAs3TZcKI0xDEw=="],
+
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
@@ -174,6 +179,8 @@
     "define-data-property": ["define-data-property@1.1.4", "", { "dependencies": { "es-define-property": "^1.0.0", "es-errors": "^1.3.0", "gopd": "^1.0.1" } }, "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A=="],
 
     "define-properties": ["define-properties@1.2.1", "", { "dependencies": { "define-data-property": "^1.0.1", "has-property-descriptors": "^1.0.0", "object-keys": "^1.1.1" } }, "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg=="],
+
+    "denque": ["denque@2.1.0", "", {}, "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw=="],
 
     "dot-prop": ["dot-prop@10.1.0", "", { "dependencies": { "type-fest": "^5.0.0" } }, "sha512-MVUtAugQMOff5RnBy2d9N31iG0lNwg1qAoAOn7pOK5wf94WIaE3My2p3uwTQuvS2AcqchkcR3bHByjaM0mmi7Q=="],
 
@@ -245,6 +252,8 @@
 
     "inversify": ["inversify@6.1.4", "", { "dependencies": { "@inversifyjs/common": "1.3.3", "@inversifyjs/core": "1.3.4" } }, "sha512-PbxrZH/gTa1fpPEEGAjJQzK8tKMIp5gRg6EFNJlCtzUcycuNdmhv3uk5P8Itm/RIjgHJO16oQRLo9IHzQN51bA=="],
 
+    "ioredis": ["ioredis@5.11.1", "", { "dependencies": { "@ioredis/commands": "1.10.0", "cluster-key-slot": "1.1.1", "debug": "4.4.3", "denque": "2.1.0", "redis-errors": "1.2.0", "redis-parser": "3.0.0", "standard-as-callback": "2.1.0" } }, "sha512-ehuGcf94bQXhfagULNXrJdfnWO38v070jxSx/qE87Kjzmu2fU7ro5EFAb+OPituLqgfyuQaym5DlrNydW2sJ9A=="],
+
     "is-arguments": ["is-arguments@1.2.0", "", { "dependencies": { "call-bound": "^1.0.2", "has-tostringtag": "^1.0.2" } }, "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA=="],
 
     "is-buffer": ["is-buffer@1.1.6", "", {}, "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="],
@@ -311,6 +320,10 @@
 
     "process": ["process@0.11.10", "", {}, "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="],
 
+    "redis-errors": ["redis-errors@1.2.0", "", {}, "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w=="],
+
+    "redis-parser": ["redis-parser@3.0.0", "", { "dependencies": { "redis-errors": "^1.0.0" } }, "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A=="],
+
     "reflect-metadata": ["reflect-metadata@0.2.2", "", {}, "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q=="],
 
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
@@ -324,6 +337,8 @@
     "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
     "source-map-support": ["source-map-support@0.5.21", "", { "dependencies": { "buffer-from": "^1.0.0", "source-map": "^0.6.0" } }, "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w=="],
+
+    "standard-as-callback": ["standard-as-callback@2.1.0", "", {}, "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="],
 
     "string-template": ["string-template@1.0.0", "", {}, "sha512-SLqR3GBUXuoPP5MmYtD7ompvXiG87QjT6lzOszyXjTM86Uu7At7vNnt2xgyTLq5o9T4IxTYFyGxcULqpsmsfdg=="],
 

--- a/standalone/docker-compose.cluster.yml
+++ b/standalone/docker-compose.cluster.yml
@@ -1,0 +1,70 @@
+# Single-node Valkey CLUSTER for LOCAL TESTING ONLY.
+#
+#   docker compose -f docker-compose.cluster.yml up -d
+#
+# This exercises the cluster code path (REDIS_CLUSTER=true: topology discovery,
+# slot routing, MOVED/ASK handling) with one master owning all 16384 slots.
+#
+# WARNING: a single node provides NO high availability (no replica, no failover).
+# For real HA use at least 3 masters + 3 replicas, or a managed Valkey/Redis
+# cluster, and point REDIS_URL at the seed nodes (comma-separated).
+
+services:
+  valkey:
+    image: valkey/valkey:9-alpine
+    container_name: cap-valkey
+    volumes:
+      - valkey-data:/data
+    command: >
+      valkey-server
+      --cluster-enabled yes
+      --cluster-config-file nodes.conf
+      --cluster-node-timeout 5000
+      --appendonly yes
+      --maxmemory-policy noeviction
+      --loglevel warning
+    healthcheck:
+      test: ["CMD", "valkey-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+    restart: unless-stopped
+
+  # One-shot: forms the single-node cluster, then exits. Idempotent.
+  valkey-init:
+    image: valkey/valkey:9-alpine
+    container_name: cap-valkey-init
+    depends_on:
+      valkey:
+        condition: service_healthy
+    entrypoint:
+      - sh
+      - -c
+      - |
+        set -e
+        if valkey-cli -h valkey cluster info | grep -q 'cluster_state:ok'; then
+          echo "Cluster already initialized, skipping."
+        else
+          # Resolve the node's container IP so it announces a network-reachable address.
+          ip=$$(getent hosts valkey | awk '{print $$1}')
+          echo "Creating single-node cluster on $$ip:6379"
+          valkey-cli --cluster create $$ip:6379 --cluster-yes
+        fi
+    restart: "no"
+
+  cap:
+    image: tiago2/cap:latest
+    container_name: cap
+    ports:
+      - "3000:3000"
+    environment:
+      ADMIN_KEY: your_secret_password
+      REDIS_CLUSTER: "true"
+      REDIS_URL: redis://valkey:6379
+    depends_on:
+      valkey-init:
+        condition: service_completed_successfully
+    restart: unless-stopped
+
+volumes:
+  valkey-data:

--- a/standalone/docker-compose.cluster.yml
+++ b/standalone/docker-compose.cluster.yml
@@ -60,7 +60,12 @@ services:
     environment:
       ADMIN_KEY: your_secret_password
       REDIS_CLUSTER: "true"
+      # Comma-separate several seed nodes in a real multi-node cluster, e.g.
+      # redis://node-1:6379,redis://node-2:6379,redis://node-3:6379
       REDIS_URL: redis://valkey:6379
+      # Optional: namespace all keys (recommended on a shared instance).
+      # Only set this on a fresh instance, never on one with existing data.
+      REDIS_PREFIX: "cap:"
     depends_on:
       valkey-init:
         condition: service_completed_successfully

--- a/standalone/package.json
+++ b/standalone/package.json
@@ -49,6 +49,7 @@
     "@elysiajs/swagger": "^1.3.1",
     "capjs-core": "^0.1.1",
     "elysia": "^1.4.28",
+    "ioredis": "^5.11.1",
     "maxmind": "^5.0.6"
   },
   "devDependencies": {

--- a/standalone/src/db.js
+++ b/standalone/src/db.js
@@ -1,89 +1,68 @@
-import { RedisClient } from "bun";
+import Redis from "ioredis";
 
-const redisUrl =
-  process.env.REDIS_URL || process.env.VALKEY_URL || "redis://localhost:6379";
 const prefix = process.env.REDIS_PREFIX || "";
+const useCluster = process.env.REDIS_CLUSTER === "true";
 
-const client = new RedisClient(redisUrl);
+// REDIS_URL may hold a comma-separated list of seed nodes in cluster mode.
+const rawUrl =
+  process.env.REDIS_URL || process.env.VALKEY_URL || "redis://localhost:6379";
 
-await client.send("PING", []);
+function parseNode(url) {
+  const u = new URL(url);
+  return { host: u.hostname, port: Number(u.port) || 6379 };
+}
 
-const addPrefix = (k) =>
-  typeof k === "string" && k.length ? prefix + k : k;
+function buildClient() {
+  if (useCluster) {
+    const urls = rawUrl
+      .split(",")
+      .map((s) => s.trim())
+      .filter(Boolean);
+    const nodes = urls.map(parseNode);
+    const seed = new URL(urls[0]);
+    return new Redis.Cluster(nodes, {
+      enableAutoPipelining: true,
+      redisOptions: {
+        keyPrefix: prefix,
+        username: seed.username || undefined,
+        password: seed.password || undefined,
+        tls: seed.protocol === "rediss:" ? {} : undefined,
+      },
+    });
+  }
+  return new Redis(rawUrl, { keyPrefix: prefix, enableAutoPipelining: true });
+}
+
+const client = buildClient();
+
+await client.ping();
+
 const stripPrefix = (k) =>
   typeof k === "string" && k.startsWith(prefix) ? k.slice(prefix.length) : k;
 
-const KEY_FIRST = new Set([
-  "get",
-  "getBuffer",
-  "getdel",
-  "set",
-  "incr",
-  "decr",
-  "expire",
-  "ttl",
-  "sadd",
-  "srem",
-  "smembers",
-  "scard",
-  "sismember",
-  "hget",
-  "hset",
-  "hmget",
-  "hgetall",
-  "hincrby",
-  "hdel",
-  "getset",
-  "append",
-]);
-
-const KEY_ALL = new Set(["del", "unlink", "exists", "mget"]);
-
-const MULTI_KEY_CMDS = new Set(["DEL", "UNLINK", "MGET", "EXISTS"]);
-
-function prefixedSend(cmd, args = []) {
-  const upper = cmd.toUpperCase();
-  if (upper === "PING" || !args.length) return client.send(cmd, args);
-  if (upper === "KEYS") {
+// Raw command escape hatch. ioredis applies keyPrefix to call() too (it knows
+// each command's key positions), so keys must NOT be prefixed manually here or
+// they would be double-prefixed relative to the builtin methods.
+function send(cmd, args = []) {
+  if (cmd.toUpperCase() === "KEYS") {
+    // ioredis prefixes the pattern but does not strip it from the reply.
     return client
-      .send(cmd, [addPrefix(args[0]), ...args.slice(1)])
+      .call(cmd, ...args)
       .then((res) => (Array.isArray(res) ? res.map(stripPrefix) : res));
   }
-  if (MULTI_KEY_CMDS.has(upper)) {
-    return client.send(cmd, args.map(addPrefix));
-  }
-  return client.send(cmd, [addPrefix(args[0]), ...args.slice(1)]);
+  return client.call(cmd, ...args);
 }
 
-const db = prefix
-  ? new Proxy(client, {
-      get(target, prop, receiver) {
-        if (prop === "send") return prefixedSend;
-        const value = Reflect.get(target, prop, receiver);
-        if (typeof value !== "function") return value;
-        if (KEY_FIRST.has(prop)) {
-          return (...args) => {
-            if (args.length) args[0] = addPrefix(args[0]);
-            return value.apply(target, args);
-          };
-        }
-        if (KEY_ALL.has(prop)) {
-          return (...args) => value.apply(target, args.map(addPrefix));
-        }
-        return value.bind(target);
-      },
-    })
-  : client;
+// ioredis exposes every command as a lowercase method with keyPrefix applied
+// automatically, so the client is used directly; only send() needs wrapping.
+client.send = send;
+
+const db = client;
 
 export async function hgetall(key) {
-  const data = await db.send("HGETALL", [key]);
-  if (!data) return {};
-  if (typeof data === "object" && !Array.isArray(data)) return data;
-  const obj = {};
-  for (let i = 0; i < data.length; i += 2) {
-    obj[data[i]] = data[i + 1];
-  }
-  return obj;
+  // Builtin method: keyPrefix is applied and the reply is already an object.
+  const data = await client.hgetall(key);
+  return data || {};
 }
 
 export { db };

--- a/standalone/test/cap-routes.test.js
+++ b/standalone/test/cap-routes.test.js
@@ -75,12 +75,14 @@ if (!redisAvailable) {
   });
 
   afterAll(async () => {
-    // Cleanup: remove the site key and any blocklist/token entries
-    await db.send("DEL", [`key:${SITE_KEY}`]);
-    await db.send("DEL", ["settings:rsw_keypair"]);
+    // Cleanup: remove the site key and any blocklist/token entries.
+    // Deletes are issued one key at a time so this works against a Redis
+    // Cluster too (a multi-key DEL would fail with CROSSSLOT).
+    await db.del(`key:${SITE_KEY}`);
+    await db.del("settings:rsw_keypair");
     const keys = await db.send("KEYS", [`metrics:*:${SITE_KEY}`]);
     if (Array.isArray(keys) && keys.length > 0) {
-      await db.send("DEL", keys);
+      await Promise.all(keys.map((k) => db.del(k)));
     }
   });
 

--- a/standalone/test/db.test.js
+++ b/standalone/test/db.test.js
@@ -1,0 +1,77 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { RedisClient } from "bun";
+
+// Exercises the db layer against whatever store REDIS_URL points at. With
+// REDIS_CLUSTER=true (see the standalone-cluster CI job) the same assertions run
+// against a Redis/Valkey Cluster, covering the cluster code path in db.js.
+
+const REDIS_URL =
+  process.env.REDIS_URL || process.env.VALKEY_URL || "redis://127.0.0.1:6379";
+
+// A non-empty prefix is required for the regression guard below to be
+// meaningful: the double-prefix bug only manifests when a prefix is set.
+process.env.REDIS_PREFIX = "captest:";
+
+let redisAvailable = false;
+try {
+  const probe = new RedisClient(REDIS_URL.split(",")[0]);
+  await probe.send("PING", []);
+  probe.close?.();
+  redisAvailable = true;
+} catch (e) {
+  console.warn("[db-test] redis not available, skipping:", e.message);
+}
+
+if (!redisAvailable) {
+  test.skip(`db layer skipped (no redis at ${REDIS_URL})`, () => {});
+} else {
+  const { db, hgetall } = await import("../src/db.js");
+  const NS = `dbtest:${Math.random().toString(16).slice(2)}`;
+
+  describe("db layer", () => {
+    afterAll(async () => {
+      // One key per DEL so cleanup is cluster-safe (no CROSSSLOT).
+      await Promise.all(
+        ["str", "cnt", "hash", "set", "nx"].map((s) => db.del(`${NS}:${s}`)),
+      );
+    });
+
+    test("string, counter and ttl", async () => {
+      await db.set(`${NS}:str`, "v1");
+      expect(await db.get(`${NS}:str`)).toBe("v1");
+      expect(await db.incr(`${NS}:cnt`)).toBe(1);
+      await db.expire(`${NS}:cnt`, 60);
+    });
+
+    test("send() and builtin methods resolve to the same key", async () => {
+      // Regression guard: keys written through the raw send() path must be
+      // readable through the builtin methods (and vice versa). ioredis applies
+      // keyPrefix to call() as well, so neither path may prefix manually, or
+      // they would diverge (e.g. captest:hash vs captest:captest:hash).
+      await db.send("HSET", [`${NS}:hash`, "a", "1", "b", "2"]);
+      await db.hincrby(`${NS}:hash`, "a", 4);
+      expect(await db.hget(`${NS}:hash`, "a")).toBe("5");
+      expect((await hgetall(`${NS}:hash`)).b).toBe("2");
+      // Read back through the raw path: must see the builtin's increment.
+      const raw = await db.send("HGETALL", [`${NS}:hash`]);
+      expect(raw).toContain("5");
+    });
+
+    test("sets and existence", async () => {
+      await db.sadd(`${NS}:set`, "x");
+      expect(await db.smembers(`${NS}:set`)).toContain("x");
+      await db.srem(`${NS}:set`, "x");
+      expect(await db.exists(`${NS}:str`)).toBeTruthy();
+      expect(await db.exists(`${NS}:missing`)).toBeFalsy();
+    });
+
+    test("SET NX EX is atomic", async () => {
+      expect(await db.send("SET", [`${NS}:nx`, "1", "NX", "EX", "30"])).toBe(
+        "OK",
+      );
+      expect(
+        await db.send("SET", [`${NS}:nx`, "1", "NX", "EX", "30"]),
+      ).toBeNull();
+    });
+  });
+}


### PR DESCRIPTION
## Add Redis Cluster support for high availability

  Migrates the standalone Redis layer from Bun's native client (which does
  not support clustering) to ioredis, adding optional Redis/Valkey Cluster
  support without changing single-node behavior.

  ### Changes
  - `db.js`: dual-mode client. `REDIS_CLUSTER=true` connects to a cluster
    using comma-separated seed nodes in `REDIS_URL`; unset keeps the existing
    single-node behavior. Key prefixing now uses ioredis' native `keyPrefix`.
  - Reads and writes are routed to masters only (no stale reads); failover is
    handled by the client.
  - Tests: new `db.test.js` covering the db layer (incl. a prefix-coherence
    regression guard) and a `cap-standalone (cluster)` CI job running the suite
    against a cluster node.
  - Docs: new "High availability (Redis Cluster)" section and a
    `docker-compose.cluster.yml` for local testing.

  ### Notes
  - `REDIS_PREFIX` stays empty by default; existing deployments are unaffected.
  - Redis Sentinel is not supported; use Cluster mode for HA.
  - ioredis becomes a dependency on all paths (not only cluster).
