### PR TITLE
fix(core): add layout checks to instrumentation and clarify guarantees

### DIFF
--- a/core/src/instrumentation.js
+++ b/core/src/instrumentation.js
@@ -326,7 +326,15 @@ function buildClientScript({
   const nKey = rVar();
   const outKey = rVar();
 
+  const layoutEl = rVar();
+  const layoutRect = rVar();
+
   const envChecks = [
+    // Layout-dependent probes: a fake DOM can stub innerText trees cheaply,
+    // but reproducing CSS box-model geometry (offsetWidth/offsetHeight and
+    // getBoundingClientRect agreement) requires a real layout engine.
+    `try { var ${layoutEl} = document.createElement('div'); ${layoutEl}.style.cssText = 'display:block;position:absolute;left:-9999px;top:0;width:137px;height:89px;padding:11px 13px;border:7px solid;margin:0;box-sizing:content-box;'; document.body.appendChild(${layoutEl}); var ${layoutRect} = ${layoutEl}.getBoundingClientRect(); var ${nKey}okw = ${layoutEl}.offsetWidth === 177 && ${layoutRect}.width === 177; var ${nKey}okh = ${layoutEl}.offsetHeight === 125 && ${layoutRect}.height === 125; document.body.removeChild(${layoutEl}); if (!${nKey}okw || !${nKey}okh) return null; } catch { return null }`,
+
     `try { const ${nKey}st = (new Error()).stack || ''; if (${nKey}st.indexOf('node:internal') !== -1 || ${nKey}st.indexOf('moduleEvaluation') !== -1 || ${nKey}st.indexOf('loadAndEvaluateModule') !== -1 || ${nKey}st.indexOf('file:///') !== -1 || ${nKey}st.indexOf('[eval]') !== -1 || /\\(native:/.test(${nKey}st)) return null; } catch { return null }`,
 
     `if (typeof HTMLElement !== 'function' || typeof Window !== 'function' || typeof Document !== 'function' || typeof Navigator !== 'function' || typeof Node !== 'function') return null; if (!(navigator instanceof Navigator) || !(document instanceof Document) || !(window instanceof Window) || !(document.body instanceof HTMLElement)) return null; if (globalThis !== window || window.self !== window || document.defaultView !== window) return null;`,

--- a/core/src/instrumentation.js
+++ b/core/src/instrumentation.js
@@ -187,7 +187,7 @@ function buildBlockChecks(b, id, hF, hSet, h) {
   const webglRendererHash = h(WEBGL_RENDERER_MARKER);
   const productSubGeckoHash = h(PRODUCTSUB_GECKO);
   const sequentumHash = h(SEQUENTUM_MARKER);
-  
+
   const checks = [];
 
   checks.push(
@@ -330,10 +330,24 @@ function buildClientScript({
   const layoutRect = rVar();
 
   const envChecks = [
-    // Layout-dependent probes: a fake DOM can stub innerText trees cheaply,
-    // but reproducing CSS box-model geometry (offsetWidth/offsetHeight and
-    // getBoundingClientRect agreement) requires a real layout engine.
-    `try { var ${layoutEl} = document.createElement('div'); ${layoutEl}.style.cssText = 'display:block;position:absolute;left:-9999px;top:0;width:137px;height:89px;padding:11px 13px;border:7px solid;margin:0;box-sizing:content-box;'; document.body.appendChild(${layoutEl}); var ${layoutRect} = ${layoutEl}.getBoundingClientRect(); var ${nKey}okw = ${layoutEl}.offsetWidth === 177 && ${layoutRect}.width === 177; var ${nKey}okh = ${layoutEl}.offsetHeight === 125 && ${layoutRect}.height === 125; document.body.removeChild(${layoutEl}); if (!${nKey}okw || !${nKey}okh) return null; } catch { return null }`,
+    // Border-box dimensions avoid zoom-dependent border rounding. Allow small
+    // subpixel differences and retry zero-sized reads while the iframe loads.
+    // This rejects incomplete DOM shims, but fixed geometry can still be faked.
+    `try {
+      var ${layoutEl} = document.createElement('div');
+      ${layoutEl}.style.cssText = 'display:block;position:absolute;left:-9999px;top:0;width:177px;height:125px;padding:11px 13px;border:7px solid;margin:0;box-sizing:border-box;';
+      document.body.appendChild(${layoutEl});
+      var ${layoutRect};
+      for (var ${nKey}attempt = 0; ${nKey}attempt < 10; ${nKey}attempt++) {
+        ${layoutRect} = ${layoutEl}.getBoundingClientRect();
+        if (${layoutRect}.width !== 0 || ${layoutRect}.height !== 0 || ${nKey}attempt === 9) break;
+        await new Promise(function(resolve) { setTimeout(resolve, 16); });
+      }
+      var ${nKey}okw = ${layoutEl}.offsetWidth === 177 && Math.abs(${layoutRect}.width - 177) <= 0.1;
+      var ${nKey}okh = ${layoutEl}.offsetHeight === 125 && Math.abs(${layoutRect}.height - 125) <= 0.1;
+      if (!${nKey}okw || !${nKey}okh) return null;
+    } catch { return null; }
+    finally { if (${layoutEl} && ${layoutEl}.parentNode) ${layoutEl}.parentNode.removeChild(${layoutEl}); }`,
 
     `try { const ${nKey}st = (new Error()).stack || ''; if (${nKey}st.indexOf('node:internal') !== -1 || ${nKey}st.indexOf('moduleEvaluation') !== -1 || ${nKey}st.indexOf('loadAndEvaluateModule') !== -1 || ${nKey}st.indexOf('file:///') !== -1 || ${nKey}st.indexOf('[eval]') !== -1 || /\\(native:/.test(${nKey}st)) return null; } catch { return null }`,
 

--- a/docs/guide/instrumentation.md
+++ b/docs/guide/instrumentation.md
@@ -6,7 +6,7 @@ description: "Cap's instrumentation challenges run server-generated JS to verify
 
 Instrumentation challenges are Cap's second layer of verification, running silently alongside the core proof-of-work system and present on Cap Standalone.
 
-They generate a unique JavaScript program on every request that is executed inside the visitor's browser. The output is checked server-side, allowing Cap to confirm that a genuine browser environment is present before accepting a token.
+They generate a unique JavaScript program on every request that is executed inside the visitor's browser. The output is checked server-side, allowing Cap to verify that the script ran against a browser-shaped environment before accepting a token. Note that this is a best-effort signal, not proof of a genuine browser: the computation is deterministic given the script, so a sufficiently complete fake DOM can in principle reproduce it outside a browser.
 
 ## How they work
 
@@ -18,7 +18,7 @@ All of these checks run inside an iframe, which `postMessage`s the answers back 
 
 ## Why DOM operations
 
-Pure arithmetic can be replicated in a non-browser environment by simply running the JavaScript. DOM operations cannot - or at least, not cheaply. Constructing real element trees, reading values through the browser's layout engine, and tearing them down again exercises a part of the browser that non-browser runtimes often stub out, do incorrectly, or skip entirely for performance. This makes the challenge harder to replay outside a genuine rendering engine.
+Pure arithmetic can be replicated in a non-browser environment by simply running the JavaScript. DOM operations make this harder - but only if they exercise semantics a fake DOM cannot cheaply reproduce. Simple `innerText` round-trips and element-tree walks can be stubbed correctly with a small fake DOM, so on their own they are a speed bump rather than a barrier. Layout-dependent reads (CSS box-model geometry via `offsetWidth`/`offsetHeight`/`getBoundingClientRect`) require an actual layout engine and raise the replay cost significantly. This is why the built-in probes include layout-dependent checks, and why instrumentation should always be paired with proof-of-work.
 
 Instrumentation challenges often also mix these with a preset list of checks.
 

--- a/docs/guide/instrumentation.md
+++ b/docs/guide/instrumentation.md
@@ -1,5 +1,5 @@
 ---
-description: "Cap's instrumentation challenges run server-generated JS to verify a real browser, working alongside proof-of-work in the self-hosted, open-source CAPTCHA."
+description: "Cap's instrumentation challenges run server-generated JS to check browser behavior alongside proof-of-work in the self-hosted, open-source CAPTCHA."
 ---
 
 # Instrumentation challenges
@@ -18,7 +18,9 @@ All of these checks run inside an iframe, which `postMessage`s the answers back 
 
 ## Why DOM operations
 
-Pure arithmetic can be replicated in a non-browser environment by simply running the JavaScript. DOM operations make this harder - but only if they exercise semantics a fake DOM cannot cheaply reproduce. Simple `innerText` round-trips and element-tree walks can be stubbed correctly with a small fake DOM, so on their own they are a speed bump rather than a barrier. Layout-dependent reads (CSS box-model geometry via `offsetWidth`/`offsetHeight`/`getBoundingClientRect`) require an actual layout engine and raise the replay cost significantly. This is why the built-in probes include layout-dependent checks, and why instrumentation should always be paired with proof-of-work.
+Pure arithmetic can be replicated in a non-browser environment by simply running the JavaScript. Simple `innerText` round-trips and element-tree walks can also be stubbed correctly with a small fake DOM. Layout-dependent reads via `offsetWidth`, `offsetHeight`, and `getBoundingClientRect()` reject shims that do not implement these APIs consistently, but fixed geometry checks can be reproduced without a layout engine. These probes are compatibility checks against expected browser behavior, not proof that a real browser is present or a guarantee of substantial replay cost.
+
+The layout probe uses border-box dimensions and a small tolerance for subpixel rounding at different zoom levels. It briefly retries zero-sized measurements while the iframe becomes rendered. An iframe that remains `display: none` cannot provide layout measurements and will fail the probe. Integrations should keep the instrumentation iframe rendered; the built-in widget positions it offscreen with zero opacity.
 
 Instrumentation challenges often also mix these with a preset list of checks.
 
@@ -28,6 +30,6 @@ Instrumentation challenges can also optionally attempt to block automated webdri
 
 ## Relationship to proof-of-work
 
-Instrumentation challenges and proof-of-work are complementary, not redundant. Proof-of-work proves *effort*: the client had to burn CPU cycles to find a hash. Instrumentation proves *environment*: the computation happened inside a browser, not a script. Together they raise the cost of abuse on two independent axes - neither alone is sufficient against a determined attacker, but both together are substantially harder to defeat simultaneously.
+Proof-of-work requires the client to perform computation to find a valid solution. Instrumentation adds a best-effort check of browser behavior, which a sufficiently complete simulation can reproduce. Instrumentation should always be paired with proof-of-work; it does not replace that computational cost or guarantee that the client used a browser.
 
 Instrumentation is not foolproof. While challenges like these are deployed at massive scale by platforms such as [YouTube](https://www.reddit.com/r/youtubedl/comments/1mkzmp3/what_is_a_po_token/) and [Twitter](https://x.com/i/js_inst), I do not recommend using them as a replacement for proof-of-work. Without PoW and with real browsers, attackers can cheaply mine these challenges.

--- a/widget/test/e2e-instrumentation.test.js
+++ b/widget/test/e2e-instrumentation.test.js
@@ -1,4 +1,5 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { inflateRawSync } from "node:zlib";
 
 let chromium;
 try {
@@ -15,6 +16,9 @@ if (!SHOULD_RUN_E2E) {
   );
   const { generateChallenge, validateChallenge } = await import(
     "../../core/src/index.js"
+  );
+  const { generateInstrumentation, verifyInstrumentationResult } = await import(
+    "../../core/src/instrumentation.js"
   );
 
   const SECRET = "instr-e2e-secret-32-bytes-padding-jjjjk!";
@@ -100,8 +104,64 @@ if (!SHOULD_RUN_E2E) {
     if (server) server.stop(true);
   });
 
+  async function runInFrame({
+    zoom = 1,
+    revealAfter,
+    css = "",
+    level = 1,
+  } = {}) {
+    const challenge = await generateInstrumentation({
+      obfuscationLevel: level,
+      blockAutomatedBrowsers: false,
+    });
+    const script = inflateRawSync(
+      Buffer.from(challenge.instrumentation, "base64"),
+    ).toString("utf8");
+    await page.goto(baseUrl);
+    const result = await page.evaluate(
+      ({ script, zoom, revealAfter, css }) =>
+        new Promise((resolve) => {
+          document.body.style.zoom = String(zoom);
+          const iframe = document.createElement("iframe");
+          iframe.setAttribute("sandbox", "allow-scripts");
+          iframe.style.cssText =
+            "position:absolute;width:1px;height:1px;top:-9999px;left:-9999px;border:none;opacity:0;pointer-events:none;";
+          if (revealAfter !== undefined) iframe.style.display = "none";
+          let revealTimer;
+          const finish = (result) => {
+            clearTimeout(timeout);
+            clearTimeout(revealTimer);
+            window.removeEventListener("message", handler);
+            iframe.remove();
+            resolve(result);
+          };
+          const handler = (event) => {
+            if (
+              event.source === iframe.contentWindow &&
+              event.data?.type === "cap:instr"
+            ) {
+              finish(event.data.result);
+            }
+          };
+          const timeout = setTimeout(() => finish(null), 2000);
+          window.addEventListener("message", handler);
+          iframe.addEventListener("load", () => {
+            if (revealAfter >= 0) {
+              revealTimer = setTimeout(() => {
+                iframe.style.display = "block";
+              }, revealAfter);
+            }
+          });
+          iframe.srcdoc = `<!doctype html><html><head><style>${css}</style></head><body><script>${script}</script></body></html>`;
+          document.body.appendChild(iframe);
+        }),
+      { script, zoom, revealAfter, css },
+    );
+    return verifyInstrumentationResult(challenge, result).valid;
+  }
+
   describe("widget e2e with instrumentation", () => {
-    test("instrumentation iframe runs and produces a token or documented error", async () => {
+    test("instrumentation iframe produces a valid token", async () => {
       await page.goto(baseUrl, { waitUntil: "domcontentloaded" });
       await page.waitForFunction(
         () =>
@@ -131,10 +191,34 @@ if (!SHOULD_RUN_E2E) {
         () => document.getElementById("errorResult").textContent,
       );
 
-      const ok =
-        (token && /^[a-z0-9]+:[a-f0-9]+$/.test(token)) || error.length > 0;
-      expect(ok).toBe(true);
+      expect(error).toBe("");
+      expect(token).toMatch(/^[a-z0-9]+:[a-f0-9]+$/);
     }, 90_000);
+
+    test("regression: layout probe waits for the iframe to become rendered", async () => {
+      expect(await runInFrame({ revealAfter: 50 })).toBe(true);
+    });
+
+    for (const zoom of [0.75, 0.9, 1, 1.1, 1.25, 1.5, 2]) {
+      test(`regression: layout probe accepts page zoom ${zoom}`, async () => {
+        for (let attempt = 0; attempt < 3; attempt++) {
+          expect(await runInFrame({ zoom })).toBe(true);
+        }
+      }, 15_000);
+    }
+
+    for (const level of [3, 7]) {
+      test(`regression: layout probe works at obfuscation level ${level}`, async () => {
+        expect(await runInFrame({ zoom: 1.25, level })).toBe(true);
+      }, 15_000);
+    }
+
+    test("layout probe still rejects unavailable or inconsistent geometry", async () => {
+      expect(await runInFrame({ revealAfter: -1 })).toBe(false);
+      expect(await runInFrame({ css: "div { transform: scale(0.5) }" })).toBe(
+        false,
+      );
+    }, 10_000);
 
     test("regression: forged cap:instr postMessage from parent window is ignored", async () => {
       const evilPage = await browser.newPage();


### PR DESCRIPTION
## Problem

Instrumentation uses deterministic computation and browser API checks. Simple DOM operations can be reproduced by a small shim, so they provide a best-effort signal rather than proof of a genuine browser.

This PR adds a geometry probe and corrects the documentation's guarantees. Review of the initial implementation found false positives: newly loaded iframes could report zero dimensions, and browser zoom changed border rounding. In headed Chromium at 125% native zoom, the base succeeded in 2/2 attempts while the original PR failed in 2/2 with `instr_timeout` after approximately 20 seconds.

## Changes

- Check a 177 x 125 border-box element through both offset dimensions and `getBoundingClientRect()`. Keep exact integer offset checks and allow 0.1 CSS pixels of rectangle rounding.
- Retry transient zero-sized rectangle measurements up to 10 times, with 16 ms between attempts. Remove the probe element in `finally`. Persistent zero or inconsistent geometry still fails.
- Add browser regressions for delayed rendering, fractional CSS zoom, obfuscation levels 3 and 7, and invalid geometry. Require a valid token and no error in the existing instrumentation end-to-end test.
- Explain that fixed geometry checks can be simulated without a layout engine. Instrumentation should remain paired with proof-of-work. Document that an iframe kept `display: none` cannot satisfy a layout probe; the built-in widget stays rendered offscreen.

## Validation

- Both new regressions failed before the correction. Fixing border rounding alone passed the zoom regression while the delayed-rendering regression still failed. Both pass with the final correction.
- Core: 101 tests passed. Full widget suite: 38 tests passed, including 13 instrumentation tests. Biome checks and `git diff --check` passed.
- Additional complete widget solves with server-side validation: 47/47 in Chromium across sampled native zoom levels from 25% to 500%, including 10/10 each in headed Chromium at 100% and 125%.
- Another 28/28 complete solves passed in Chromium and Firefox, including display scale 1.25 and 2. Supported iframe scenarios also passed with parent CSS zoom, transforms, CSS resets, hidden visibility, a mobile-sized viewport, and visual accessibility preferences.
- Browsers: Chromium 136.0.7103.25 for the repository suite; Chromium 152.0.7977.82 and Firefox 151.0 for additional compatibility tests. Additional full-flow checks used obfuscation level 1 and `blockAutomatedBrowsers: false` to isolate the layout probe.

Safari and physical mobile devices were not validated. The viewport checks are simulations. Separate exploratory checks found that obfuscation levels 8 and 9 already fail on the base commit with `javascript-obfuscator` installed, as well as on the original PR and corrected code. That pre-existing issue is outside this layout correction; these results do not claim that all obfuscation levels work.

AI-assisted contribution, reviewed and tested.
