### PR TITLE
fix(standalone): verify site secrets with SHA-256 instead of argon2id

### DIFF
--- a/standalone/src/secret-hash.js
+++ b/standalone/src/secret-hash.js
@@ -1,0 +1,28 @@
+import { createHash, timingSafeEqual } from "node:crypto";
+
+const PREFIX = "sha256:";
+
+const sha256Hex = (s) => createHash("sha256").update(s).digest("hex");
+
+export function hashSecret(secret) {
+  return PREFIX + sha256Hex(secret);
+}
+
+export function isFastHash(stored) {
+  return typeof stored === "string" && stored.startsWith(PREFIX);
+}
+
+// Returns { valid, legacy }. `legacy` is true when `stored` is an old
+// password-KDF hash that verified successfully allowing the hash to be regenerated as SHA-256
+export async function verifySecret(secret, stored) {
+  if (isFastHash(stored)) {
+    const a = Buffer.from(sha256Hex(secret), "hex");
+    const b = Buffer.from(stored.slice(PREFIX.length), "hex");
+    const valid = a.length === b.length && timingSafeEqual(a, b);
+    return { valid, legacy: false };
+  }
+
+  // Legacy argon2/bcrypt hashes
+  const valid = await Bun.password.verify(secret, stored);
+  return { valid, legacy: valid };
+}

--- a/standalone/src/server.js
+++ b/standalone/src/server.js
@@ -17,6 +17,7 @@ import {
   getStatus as getIPDBStatus,
 } from "./ipdb.js";
 import { ensureRswKeypair, getRswStatus } from "./rsw-store.js";
+import { hashSecret } from "./secret-hash.js";
 import {
   invalidateCorsCache,
   setCorsDefault,
@@ -168,7 +169,7 @@ export const server = new Elysia({
         "name",
         body?.name || siteKey,
         "secretHash",
-        await Bun.password.hash(secretKey),
+        hashSecret(secretKey),
         "jwtSecret",
         jwtSecret,
         "config",
@@ -592,7 +593,7 @@ export const server = new Elysia({
 
       await db.hmset(`key:${params.siteKey}`, [
         "secretHash",
-        await Bun.password.hash(newSecretKey),
+        hashSecret(newSecretKey),
       ]);
 
       return {

--- a/standalone/src/siteverify.js
+++ b/standalone/src/siteverify.js
@@ -1,6 +1,7 @@
 import { Elysia } from "elysia";
 
 import { db } from "./db.js";
+import { hashSecret, verifySecret } from "./secret-hash.js";
 
 export const siteverifyServer = new Elysia({
   detail: {
@@ -35,11 +36,16 @@ export const siteverifyServer = new Elysia({
     return { success: false, error: "Invalid site key or secret" };
   }
 
-  const isValidSecret = await Bun.password.verify(secret, secretHash);
+  const { valid, legacy } = await verifySecret(secret, secretHash);
 
-  if (!isValidSecret) {
+  if (!valid) {
     set.status = 403;
     return { success: false, error: "Invalid site key or secret" };
+  }
+
+  // Upgrade legacy password-KDF hashes to SHA-256
+  if (legacy) {
+    await db.hset(`key:${sitekey}`, "secretHash", hashSecret(secret));
   }
 
   const tokenKey = `token:${response}`;


### PR DESCRIPTION
Because site secrets are high entropy tokens that are already hard to bruteforce Argon2 is a bad fit for the hash. SHA-256 is much faster and since the token must be hashed on every verify request it costs valuable cpu and memory.

The rough benchmarking numbers I got were 64 MiB of memory and ~160ms per Argon2 hash vs microseconds for the SHA-256 hash

The current hashing behavior can also lead to a possible denial of service attack by spamming a large quantity of invalid secrets costing a large amount of memory and cpu usage.

generated initially with claude opus 5 and then tweaked and reviewed before pring